### PR TITLE
Save recipes via branch + PR instead of direct push to main

### DIFF
--- a/app/src/app/api/recipes/[slug]/route.ts
+++ b/app/src/app/api/recipes/[slug]/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifySessionToken } from '@/lib/auth';
-import { getRecipeFile, saveRecipeFile, titleToSlug } from '@/lib/github';
+import { saveRecipeFile } from '@/lib/github';
 import { buildRecipeMarkdown } from '@/lib/recipes';
-import { revalidatePath } from 'next/cache';
 
 async function authenticate(request: NextRequest) {
   const token = request.cookies.get('session')?.value;
@@ -21,14 +20,8 @@ export async function PUT(
   const { slug } = await params;
   const { title, tags, servings, body } = await request.json();
 
-  const existing = await getRecipeFile(slug);
-  if (!existing) return NextResponse.json({ error: 'Recipe not found' }, { status: 404 });
-
   const content = buildRecipeMarkdown(title, tags, servings, body);
-  await saveRecipeFile(slug, content, `Update: ${title}`, existing.sha);
+  const { prUrl } = await saveRecipeFile(slug, content, `Update: ${title}`);
 
-  revalidatePath(`/recipes/${slug}`);
-  revalidatePath('/');
-
-  return NextResponse.json({ ok: true });
+  return NextResponse.json({ ok: true, prUrl });
 }

--- a/app/src/app/api/recipes/route.ts
+++ b/app/src/app/api/recipes/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { verifySessionToken } from '@/lib/auth';
 import { saveRecipeFile, titleToSlug } from '@/lib/github';
 import { buildRecipeMarkdown } from '@/lib/recipes';
-import { revalidatePath } from 'next/cache';
 
 async function authenticate(request: NextRequest) {
   const token = request.cookies.get('session')?.value;
@@ -22,9 +21,7 @@ export async function POST(request: NextRequest) {
 
   const slug = titleToSlug(title);
   const content = buildRecipeMarkdown(title, tags ?? [], servings ?? '', body ?? '');
-  await saveRecipeFile(slug, content, `Add: ${title}`);
+  const { prUrl } = await saveRecipeFile(slug, content, `Add: ${title}`);
 
-  revalidatePath('/');
-
-  return NextResponse.json({ ok: true, slug });
+  return NextResponse.json({ ok: true, slug, prUrl });
 }

--- a/app/src/components/RecipeEditor.tsx
+++ b/app/src/components/RecipeEditor.tsx
@@ -33,6 +33,7 @@ export default function RecipeEditor({
   const [body, setBody] = useState(initialBody);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  const [prUrl, setPrUrl] = useState('');
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
 
   // Stable options object — initialValue seeds EasyMDE's CodeMirror instance on first mount
@@ -67,8 +68,7 @@ export default function RecipeEditor({
     if (!res.ok) {
       setError(data.error ?? 'Save failed');
     } else {
-      router.push(`/recipes/${isNew ? data.slug : slug}`);
-      router.refresh();
+      setPrUrl(data.prUrl);
     }
   }
 
@@ -156,6 +156,16 @@ export default function RecipeEditor({
       </div>
 
       {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {prUrl && (
+        <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
+          Recipe saved.{' '}
+          <a href={prUrl} target="_blank" rel="noopener noreferrer" className="font-medium underline">
+            View pull request on GitHub
+          </a>
+          {' '}— merge it to publish the changes to the live site.
+        </div>
+      )}
 
       <div className="flex gap-3">
         <button

--- a/app/src/lib/github.ts
+++ b/app/src/lib/github.ts
@@ -41,20 +41,81 @@ export async function getRecipeFile(
   }
 }
 
-/** Create or update a recipe file via a GitHub commit. */
+function slugToBranch(slug: string): string {
+  return `recipe-edit/${slug.toLowerCase().replace(/_/g, '-').replace(/[^a-z0-9-]/g, '')}`;
+}
+
+/**
+ * Save a recipe by committing to a per-recipe branch and opening (or updating)
+ * a pull request. Returns the PR URL so the caller can show it to the user.
+ * Direct pushes to main are blocked by branch protection rules.
+ */
 export async function saveRecipeFile(
   slug: string,
   content: string,
-  message: string,
-  sha?: string
-): Promise<void> {
+  message: string
+): Promise<{ prUrl: string }> {
+  const octokit = client();
+  const branch = slugToBranch(slug);
+  const filePath = `${RECIPES_PATH}/${slugToFilename(slug)}`;
   const encoded = Buffer.from(content, 'utf8').toString('base64');
-  await client().repos.createOrUpdateFileContents({
-    owner: OWNER,
-    repo: REPO,
-    path: `${RECIPES_PATH}/${slugToFilename(slug)}`,
+
+  // Get the current SHA of main so we can branch from it
+  const mainRef = await octokit.git.getRef({ owner: OWNER, repo: REPO, ref: 'heads/main' });
+  const mainSha = mainRef.data.object.sha;
+
+  // Create the edit branch if it doesn't already exist
+  try {
+    await octokit.git.createRef({
+      owner: OWNER, repo: REPO,
+      ref: `refs/heads/${branch}`,
+      sha: mainSha,
+    });
+  } catch (err: any) {
+    if (err.status !== 422) throw err; // 422 = branch already exists, that's fine
+  }
+
+  // Get the current file SHA on the branch (needed for updates)
+  let fileSha: string | undefined;
+  try {
+    const existing = await octokit.repos.getContent({
+      owner: OWNER, repo: REPO,
+      path: filePath,
+      ref: branch,
+    });
+    fileSha = (existing.data as { sha: string }).sha;
+  } catch {
+    // File doesn't exist on branch yet (new recipe)
+  }
+
+  // Commit the file to the branch
+  await octokit.repos.createOrUpdateFileContents({
+    owner: OWNER, repo: REPO,
+    path: filePath,
     message,
     content: encoded,
-    ...(sha ? { sha } : {}),
+    branch,
+    ...(fileSha ? { sha: fileSha } : {}),
   });
+
+  // Open a PR if none exists for this branch, otherwise return the existing one
+  const openPrs = await octokit.pulls.list({
+    owner: OWNER, repo: REPO,
+    head: `${OWNER}:${branch}`,
+    state: 'open',
+  });
+
+  if (openPrs.data.length > 0) {
+    return { prUrl: openPrs.data[0].html_url };
+  }
+
+  const pr = await octokit.pulls.create({
+    owner: OWNER, repo: REPO,
+    title: message,
+    head: branch,
+    base: 'main',
+    body: 'Recipe edit submitted via the recipe app. Merge to publish.',
+  });
+
+  return { prUrl: pr.data.html_url };
 }


### PR DESCRIPTION
Branch protection requires PRs, so each save now:
1. Creates a branch `recipe-edit/{slug}` from main
2. Commits the file there (re-uses the branch if it already exists)
3. Opens a PR (or returns the existing open PR URL)

The editor shows a green banner with a link to the PR after saving. Changes go live once the PR is merged and Vercel redeploys.