### PR TITLE
Redirect to edit page with full navigation after OTP verification

### DIFF
--- a/app/src/app/login/page.tsx
+++ b/app/src/app/login/page.tsx
@@ -46,7 +46,8 @@ function LoginForm() {
     if (!res.ok) {
       setError(data.error ?? 'Something went wrong');
     } else {
-      router.push(next);
+      // Full navigation so the new session cookie is included in the next request
+      window.location.href = next;
     }
   }
 


### PR DESCRIPTION
router.push() does a client-side navigation that may use a cached route check without the freshly-set session cookie, leaving the user on the login page. window.location.href forces a full HTTP request so the proxy sees the new cookie and allows through to the intended edit page.